### PR TITLE
add support for multiple databases

### DIFF
--- a/data_tests/admin.py
+++ b/data_tests/admin.py
@@ -23,7 +23,8 @@ class TestResultAdmin(admin.ModelAdmin):
 
     def object_link(self, obj):
         try:
-            return obj.object_admin_hyperlink(str(obj.object))
+            link_name = str(obj.get_object())
+            return obj.object_admin_hyperlink(link_name)
         except NoReverseMatch:
             return 'No admin page implemented'
     object_link.allow_tags = True


### PR DESCRIPTION
Allow test_method to be used on models that don't route to the default database.

The GenericForeinKey TestResult.object is replaced with a function TestResult.get_object() that can pull a record from any database. I optimized some of the lookups with lru_cache keep the run time equivalent to GenericForeignKey (which isn't so fast to begin with).

