### PR TITLE
replace .object with ._base_manager

### DIFF
--- a/data_tests/models.py
+++ b/data_tests/models.py
@@ -42,7 +42,7 @@ class TestMethod(models.Model):
             logger.info('Deleted {} stale test results'.format(deleted))
 
     def add_new_result_objects(self):
-        all_object_pks = set(self.model_class().objects.values_list('pk', flat=True))
+        all_object_pks = set(self.model_class()._base_manager.values_list('pk', flat=True))
         existing_test_results = set(self.test_results.values_list('object_id', flat=True))
         to_insert = []
         for new_id in all_object_pks - existing_test_results:


### PR DESCRIPTION
the `objects` manager can be overwritten or removed from a model, but _base_manager should always refer to the default implementation on Models. You might also consider _default_manager which is the first manager defined on the Model.